### PR TITLE
Code fix for identifier-semantics-IT on snomed-ct-data

### DIFF
--- a/plugin/snomed-ct-transformation-maven-plugin/src/main/java/dev/ikm/maven/SnomedTransformationMojo.java
+++ b/plugin/snomed-ct-transformation-maven-plugin/src/main/java/dev/ikm/maven/SnomedTransformationMojo.java
@@ -6,19 +6,17 @@ import dev.ikm.tinkar.common.service.ServiceKeys;
 import dev.ikm.tinkar.common.service.ServiceProperties;
 import dev.ikm.tinkar.composer.Composer;
 import dev.ikm.tinkar.entity.EntityService;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-
 import org.apache.maven.plugins.annotations.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -62,19 +60,19 @@ public class SnomedTransformationMojo extends AbstractMojo {
 
     private String unzipRawData(String zipFilePath) throws IOException {
         File outputDirectory = new File(dataOutputPath);
-        try(ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFilePath))) {
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFilePath))) {
             ZipEntry zipEntry;
             while ((zipEntry = zis.getNextEntry()) != null) {
                 File newFile = new File(outputDirectory, zipEntry.getName());
-                if(zipEntry.isDirectory()) {
+                if (zipEntry.isDirectory()) {
                     newFile.mkdirs();
                 } else {
                     new File(newFile.getParent()).mkdirs();
-                    try(FileOutputStream fos = new FileOutputStream(newFile)) {
+                    try (FileOutputStream fos = new FileOutputStream(newFile)) {
                         byte[] buffer = new byte[1024];
                         int len;
                         while ((len = zis.read(buffer)) > 0) {
-                            fos.write(buffer,0,len);
+                            fos.write(buffer, 0, len);
                         }
                     }
                 }
@@ -91,12 +89,12 @@ public class SnomedTransformationMojo extends AbstractMojo {
     }
 
     private static File searchTerminologyFolder(File dir) {
-        if (dir.isDirectory()){
+        if (dir.isDirectory()) {
             File[] files = dir.listFiles();
             if (files != null) {
                 for (File file : files) {
-                    if(file.isDirectory() && file.getName().equals("Terminology") &&
-                        file.getParentFile().getName().equals("Full")) {
+                    if (file.isDirectory() && file.getName().equals("Terminology") &&
+                            file.getParentFile().getName().equals("Full")) {
                         return file;
                     }
                     File found = searchTerminologyFolder(file);
@@ -110,7 +108,7 @@ public class SnomedTransformationMojo extends AbstractMojo {
     }
 
     private void validateInputDirectory(File inputFileOrDirectory) throws MojoExecutionException {
-        if(!inputFileOrDirectory.exists()){
+        if (!inputFileOrDirectory.exists()) {
             throw new RuntimeException("Invalid input directory or file. Directory or file does not exist");
         }
     }
@@ -118,10 +116,10 @@ public class SnomedTransformationMojo extends AbstractMojo {
     /**
      * Transforms each snomed file in a directory based on filename
      *
-     * @param datastore location of datastore to write entities to
+     * @param datastore            location of datastore to write entities to
      * @param inputFileOrDirectory directory containing snomed files
      */
-    public void transformFile(File datastore, File inputFileOrDirectory){
+    public void transformFile(File datastore, File inputFileOrDirectory) {
         LOG.info("########## Snomed Transformer Starting...");
         initializeDatastore(datastore);
 
@@ -137,15 +135,15 @@ public class SnomedTransformationMojo extends AbstractMojo {
         }
     }
 
-    private void initializeDatastore(File datastore){
+    private void initializeDatastore(File datastore) {
         CachingService.clearAll();
         ServiceProperties.set(ServiceKeys.DATA_STORE_ROOT, datastore);
         PrimitiveData.selectControllerByName(controllerName);
         PrimitiveData.start();
     }
 
-    private void processFilesFromInput(File inputFileOrDirectory, Composer composer){
-        if(inputFileOrDirectory.isDirectory()){
+    private void processFilesFromInput(File inputFileOrDirectory, Composer composer) {
+        if (inputFileOrDirectory.isDirectory()) {
             Arrays.stream(inputFileOrDirectory.listFiles())
                     .filter(file -> file.getName().endsWith(".txt"))
                     .forEach(file -> processIndividualFile(file, composer));
@@ -173,15 +171,17 @@ public class SnomedTransformationMojo extends AbstractMojo {
      * @param fileName File for Transformer match
      */
     private Transformer getTransformer(String fileName) {
-        if(fileName.contains("Concept")){
+        if (fileName.contains("Concept")) {
             return new ConceptTransformer(namespace);
-        } else if(fileName.contains("Definition")){
+        } else if (fileName.contains("Definition")) {
             return new DefinitionTransformer(namespace);
-        } else if(fileName.contains("Description")){
+        } else if (fileName.contains("Description")) {
             return new DescriptionTransformer(namespace);
-        } else if(fileName.contains("Language")){
+        } else if (fileName.contains("Language")) {
             return new LanguageTransformer(namespace);
-        } else if(fileName.contains("OWLExpression")){
+        } else if (fileName.contains("Identifier")) {
+            return new IdentifierTransformer(namespace);
+        } else if (fileName.contains("OWLExpression")) {
             return new AxiomSyntaxTransformer(namespace);
         }
         return null;

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>dev.ikm.tinkar</groupId>
         <artifactId>snomed-ct-data-bom</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.3.0</version>
         <relativePath/>
     </parent>
 

--- a/snomed-ct-integration/src/test/java/dev/ikm/tinkar/snomedct/integration/AbstractIntegrationTest.java
+++ b/snomed-ct-integration/src/test/java/dev/ikm/tinkar/snomedct/integration/AbstractIntegrationTest.java
@@ -82,7 +82,7 @@ public abstract class AbstractIntegrationTest {
              BufferedWriter bw = new BufferedWriter(new FileWriter(errorFile))) {
             String line;
             while ((line = br.readLine()) != null) {
-                if (line.startsWith("id")) continue;
+                if ((line.startsWith("id")) || (line.startsWith("alternateIdentifier"))) continue;
                 if (!assertLine(line.split("\\t"))) {
                     notFound++;
                     bw.write(line);

--- a/snomed-ct-integration/src/test/java/dev/ikm/tinkar/snomedct/integration/IdentifierSemanticIT.java
+++ b/snomed-ct-integration/src/test/java/dev/ikm/tinkar/snomedct/integration/IdentifierSemanticIT.java
@@ -1,27 +1,17 @@
 package dev.ikm.tinkar.snomedct.integration;
 
 import dev.ikm.maven.SnomedUtility;
-import dev.ikm.tinkar.common.id.PublicId;
-import dev.ikm.tinkar.common.id.PublicIds;
 import dev.ikm.tinkar.common.util.uuid.UuidUtil;
-import dev.ikm.tinkar.coordinate.Calculators;
 import dev.ikm.tinkar.coordinate.stamp.StampCoordinateRecord;
 import dev.ikm.tinkar.coordinate.stamp.StampPositionRecord;
 import dev.ikm.tinkar.coordinate.stamp.StateSet;
 import dev.ikm.tinkar.coordinate.stamp.calculator.Latest;
 import dev.ikm.tinkar.coordinate.stamp.calculator.StampCalculator;
 import dev.ikm.tinkar.entity.ConceptRecord;
-import dev.ikm.tinkar.entity.ConceptVersionRecord;
 import dev.ikm.tinkar.entity.EntityService;
 import dev.ikm.tinkar.entity.EntityVersion;
-import dev.ikm.tinkar.entity.PatternEntityVersion;
-import dev.ikm.tinkar.entity.PublicIdentifierRecord;
-import dev.ikm.tinkar.entity.SemanticRecord;
-import dev.ikm.tinkar.entity.SemanticVersionRecord;
 import dev.ikm.tinkar.terms.EntityFacade;
-import dev.ikm.tinkar.terms.EntityProxy;
 import dev.ikm.tinkar.terms.TinkarTerm;
-import org.eclipse.collections.api.list.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -31,13 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IdentifierSemanticIT extends AbstractIntegrationTest {
     /**
-     * Test Snomed Loinc Identifier Semantics.
+     * Test Snomed Identifier Semantics.
      *
      * @result Reads content from file and validates Identifier of Semantics by calling protected method assertLine().
      */
     @Test
     public void testIdentifierSemantics() throws IOException {
-        String sourceFilePath = "../snomed-ct-loinc-origin/target/origin-sources";
+        String sourceFilePath = "../snomed-ct-origin/target/origin-sources";
         String errorFile = "target/failsafe-reports/identifiers_not_found.txt";
 
         String absolutePath = findFilePath(sourceFilePath, "sct2_identifier");


### PR DESCRIPTION
Current fixes solve the following: 
- roll back snomed-ct-data-bom to version 1.3.0
- Add validation on AbstractIntegrationTest.java to read from Identifier file.
- On Integration Test fix sourceFilePath to find errorFile.